### PR TITLE
Altered CSS for header & footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
             <a href="#">VOLUNTEER</a>
         </nav>
     </header>
-    <div class="hero" style="background: linear-gradient(0deg, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url('//static.wixstatic.com/media/77bb36_872a40e8b36c4aef9732d69cdb7d5bc1~mv2_d_2048_1365_s_2.jpg'); background-position: center; background-size: cover;">
+    <div class="hero" style="background: linear-gradient(0deg, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url('https://static.wixstatic.com/media/77bb36_872a40e8b36c4aef9732d69cdb7d5bc1~mv2_d_2048_1365_s_2.jpg'); background-position: center; background-size: cover;">
         <h1>Welcome to MassFTC</h1>
         <i>The official affiliate partner for FIRST Tech Challenge in Massachusetts</i>
         <br><br>
@@ -45,7 +45,7 @@
 
     <footer>
 
-        &copy; 2019 Massachusetts FTC
+        <span class="copyright">&copy; 2019 Massachusetts FTC</span>
         <nav>
             <a href="mailto:massftc@gmail.com">Email Us</a>
         </nav>

--- a/massftc.css
+++ b/massftc.css
@@ -32,6 +32,7 @@ header nav, footer nav {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+	margin-left: auto;
 }
 
 header nav a, footer nav a {
@@ -152,7 +153,11 @@ footer nav a {
     }
 }
 
-@media screen and (min-width: 600px) {
+@media only screen and (min-width: 600px) {
+	header, footer {
+		flex-direction: row;
+		align-items: center;
+	}
     header nav, footer nav {
         flex-direction: row;
     }


### PR DESCRIPTION
I noticed that on desktop, the header and footer's children were still in column orientation. I changed that to row (and `align-item`'d them to center) so that the items in header & footer will display on the same line. I also changed the deprecated protocol-relative URL for the main page's splash image (`//`) to `https://`.